### PR TITLE
Add an example here to explain how the "filter" option works

### DIFF
--- a/doc/module_base.html
+++ b/doc/module_base.html
@@ -186,7 +186,7 @@ attribute ::= id
             | "!" expr            # negation]]></hcode>
 </li>
 </ul>
-<p>Example: <ixml>&lt;documents type="post" max="10" rss="index.rss"/&gt;</ixml></p>
+<p>Example: <ixml>&lt;documents type="post" max="10" rss="index.rss" filter=""/&gt;</ixml></p>
 </subsection>
 
 <subsection id="doc-bodyx" title="doc-body">


### PR DESCRIPTION
You may insert an expression selection all documents belonging to a set, an attribute, or located in a given folder.

Currently, the syntax of the `filter` attribute is quite unclear, I couldn't find how to use it after dozens of trial.