### PR TITLE
fix hardcoded temp directory for latex

### DIFF
--- a/src/stog_latex.ml
+++ b/src/stog_latex.ml
@@ -114,8 +114,9 @@ let make_svg outdir ?(packages=[]) ?(scale=1.1) ?(def_files=[]) ?defs latex_code
       Stog_misc.file_of_string ~file: tex code;
       let log = Filename.temp_file "stog" ".log" in
       let command = Printf.sprintf
-        "(latex -output-directory=/tmp -interaction=batchmode %s > %s 2>&1) && \
+        "(latex -output-directory=%s -interaction=batchmode %s > %s 2>&1) && \
          dvisvgm -e --scale=%f -M 1.5 --no-fonts %s -s 2>> %s > %s"
+          (Filename.get_temp_dir_name ())
           (Filename.quote tex) (Filename.quote log)
           scale
           (Filename.quote dvi)


### PR DESCRIPTION
`<latex>...</latex>` block converted to empty (size zero) svg on Mac OS X.

The reason: on Mac OS X temporary files are created not in /tmp but in another place (something along the lines of "/var/folders/^C/2b753l4s6sn3nckgqnf7v9zw0000gn/T"); dvisvgm is expecting to find generated .dvi there, but latex is instructed to output it to /tmp.