### PR TITLE
Call tail in BSD-friendly way

### DIFF
--- a/src/stog_misc.ml
+++ b/src/stog_misc.ml
@@ -264,7 +264,7 @@ let list_concat ?sep l =
 
 let dot_to_svg dot =
   let temp_file = Filename.temp_file "genet" "svg" in
-  let com = Printf.sprintf "echo %s | dot -Tsvg | tail --lines=+7 > %s"
+  let com = Printf.sprintf "echo %s | dot -Tsvg | tail -n +7 > %s"
     (Filename.quote dot) (Filename.quote temp_file)
   in
   match Sys.command com with


### PR DESCRIPTION
'--lines' option of tail is Linux-specific; '-n' works both for Linux and BSD.