### PR TITLE
Correct lastmod date in sitemap

### DIFF
--- a/src/plugins/stog_sitemap.ml
+++ b/src/plugins/stog_sitemap.ml
@@ -94,7 +94,7 @@ let gen_sitemap stog data entries =
      node ("","url")
       ((node ("","loc") [cdata (Stog_url.to_string e.url_loc)]) ::
         (node ("","lastmod")
-         [cdata (Netdate.format ~fmt: "%d %b %Y %T %z" e.url_lastmod)]
+         [cdata (Netdate.format ~fmt: "%Y-%m-%dT%T%:z" e.url_lastmod)]
         ) ::
           (match e.url_freq with
              None -> []


### PR DESCRIPTION
Date should be in [W3C Datetime format](http://www.w3.org/TR/NOTE-datetime), according to http://www.sitemaps.org/protocol.html.

Current format of date is not recognised by Google.

*I didn't build stog with this, but it should work. I tested the format with `date` command and the library.*