### PR TITLE
Add contextual help with the preview server

### DIFF
--- a/src/stog_server_main.ml
+++ b/src/stog_server_main.ml
@@ -44,7 +44,9 @@ let start_server current_state ~http_url ~ws_url base_path =
   let host = Stog_url.host http_url.priv in
   let port = Stog_url.port http_url.priv in
   Lwt_io.write Lwt_io.stdout
-    (Printf.sprintf "Listening for HTTP request on: %s:%d\n" host port)
+    (Printf.sprintf "Listening for HTTP request on: %s:%d\n\
+    Open http://%s:%s/preview"
+      host port host port)
   >>= fun _ ->
   let conn_closed (_,id) =
     ignore(Lwt_io.write Lwt_io.stdout


### PR DESCRIPTION
This saves the user from browsing the documentation (https://zoggy.github.io/stog/server.html) to find why opening the browser on the listening address is not working.

However, the style of the code may be improved, since we pass the same argument twice.

It may be interesting to add the same sort of thing for the editor.