### PR TITLE
Update opam dependencies

### DIFF
--- a/opam
+++ b/opam
@@ -28,6 +28,9 @@ depends: [
   "ocamlnet" {>= "3.6"}
   "higlo" { >= "0.5" }
   "ppx_blob" { >= "0.1" }
+  "ptime"
+  "uri"
+  "omd"
 ]
 depopts: [
   "js_of_ocaml"


### PR DESCRIPTION
Tried to install stog with ocaml 4.03.0 from master branch, and had to install this (manually) to make it work.

Did not check optional dependencies, got problems with ojs-base and gave up.